### PR TITLE
fix(paginate): satisfy clippy::unnecessary_sort_by on Rust 1.95

### DIFF
--- a/src/utils/paginate.rs
+++ b/src/utils/paginate.rs
@@ -147,7 +147,7 @@ where
                 .await
                 .map_err(db_error)?;
 
-            res.sort_by(|a, b| b.date.cmp(&a.date));
+            res.sort_by_key(|p| std::cmp::Reverse(p.date));
 
             let (min, max) = get_published_posts_min_max_id(db).await?;
 


### PR DESCRIPTION
## Summary
- Replace `sort_by(|a, b| b.date.cmp(&a.date))` with `sort_by_key(|p| Reverse(p.date))` in `src/utils/paginate.rs` to clear Rust 1.95's new `clippy::unnecessary_sort_by` lint that is breaking CI on every open PR (e.g. #219).

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes locally
- [ ] CI Clippy job turns green